### PR TITLE
Bump log4net to 3.3.1

### DIFF
--- a/examples/files-cli/files-cli.csproj
+++ b/examples/files-cli/files-cli.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FilesCom" Version="1.4.548" />
-    <PackageReference Include="log4net" Version="2.0.10" />
+    <PackageReference Include="log4net" Version="3.3.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0-preview.1.20120.5" />
     <PackageReference Include="ManyConsole" Version="2.0.1" />
   </ItemGroup>

--- a/sdk/FilesCom/FilesCom.csproj
+++ b/sdk/FilesCom/FilesCom.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.10" />
+    <PackageReference Include="log4net" Version="3.3.1" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
     <PackageReference Include="Polly" Version="7.2.1" />


### PR DESCRIPTION
## Summary
- Bumps the SDK package dependency on `log4net` from `2.0.10` to `3.3.1`.
- Updates the example CLI direct `log4net` reference to match.
- Fixes #14.

## Test plan
- `dotnet restore sdk/Files.com.sln` passes; existing NU190x warnings remain for old target framework/runtime packages and `System.Text.Json`.
- `dotnet build sdk/Files.com.sln` passes; existing warnings remain.
- `dotnet test sdk/Files.com.sln` passes: 56 passed, 0 failed.
- `dotnet pack sdk/FilesCom/FilesCom.csproj -c Release` passes.
- Inspected `FilesCom.1.4.548.nupkg`: all 9 `log4net` dependency entries are now `3.3.1`.